### PR TITLE
Trim the whitespaces from tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ jQuery selector for the columns you don't want to export in the csv (tipically a
 `default: ''`  
 jQuery selector for the rows you don't want to export in the csv (tipically a list of classes)
 
+* trimContent
+`default: true`
+Trims the content of individual <th>, <td> tags of whitespaces. This will produce valid output even if the table is indented.
+
 #### Download options
 
 These options apply only when the 'download' action is used

--- a/src/table2csv.js
+++ b/src/table2csv.js
@@ -13,6 +13,7 @@
 		separator: ',',
 		newline: '\n',
 		quoteFields: true,
+		trimContent: true,
 		excludeColumns: '',
 		excludeRows: ''
 	};
@@ -47,7 +48,10 @@
 			.each(function(i, col) {
 				col = $(col);
 				
-				output += options.quoteFields ? quote(col.text()) : col.text();
+				// Strip whitespaces
+				var content = options.trimContent ? $.trim(col.text()) : col.text();
+				
+				output += options.quoteFields ? quote(content) : content;
 				if(i != numCols-1) {
 					output += options.separator;
 				} else {


### PR DESCRIPTION
I had an issue with the plugin, when it reflected tabs and newlines from HTML indentation into the CSV file and thus rendered it invalid.
I added boolean option to enable trimming of whitespaces from the content of td and th tags. It will trim only leading/trailing whitespaces, so the spaces inside the content (such as sentences) will remain.

Review and merge if you like.